### PR TITLE
Disable nginx max upload size

### DIFF
--- a/web-context/sites-enabled/hgserver_nginx.conf
+++ b/web-context/sites-enabled/hgserver_nginx.conf
@@ -10,7 +10,7 @@ server {
     charset     utf-8;
 
     # max upload size
-    client_max_body_size 10000M;   # adjust to taste
+    client_max_body_size 0;   # adjust to taste
 
     location /api/v1/ {
         uwsgi_pass  django;


### PR DESCRIPTION
Disable max_client_body_size checking within the container.
Reference: http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size

On production systems this should be enforced on the reverse proxy that handles the SSL termination. 